### PR TITLE
Reduce the size of hashes for readability.

### DIFF
--- a/gtranslate.py
+++ b/gtranslate.py
@@ -155,7 +155,11 @@ def handle_single_xml_element_translation(existing_xml_element, single_xml_eleme
 # Returns hash of a string
 def encode(text):
     result = hashlib.md5(text.encode())
-    return result.hexdigest()
+    h = result.hexdigest()
+
+    # Truncate the hash for readability of the generated files.
+    # An entropy of 16^8 means less than a one in 4 billion chance of any 2 strings having a hash collision.
+    return h[:8]
 
 
 # Finds and returns xml element if exists in the given root.


### PR DESCRIPTION
So instead of:
```
<string name="done" translated-from="f92965e2c8a7afb3c1b9a5c09a263636">Hecho</string>
```

 it's now:

```
<string name="done" translated-from="f92965e2">Hecho</string>
```